### PR TITLE
[feature/look-ahead] FIX small bug

### DIFF
--- a/library/ngx-scrollspy/package.json
+++ b/library/ngx-scrollspy/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uniprank/ngx-scrollspy",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "author": {
         "name": "Dennis Fiedler",
         "email": "npm-package@uniprank.com",

--- a/library/ngx-scrollspy/src/lib/scroll-spy.service.ts
+++ b/library/ngx-scrollspy/src/lib/scroll-spy.service.ts
@@ -109,6 +109,7 @@ export class ScrollSpyService {
     }
 
     private _setDefaultItem(itemId: string, scrollElementId: string): void {
+        if (this._lookAhead) return;
         const _value = this._scrollElementListener[scrollElementId];
         if (_value == null) {
             this._setScrollElementListener(scrollElementId, this._scrollItems[itemId]);


### PR DESCRIPTION
The code was still setting the first scroll item as active on page load.
Now if the look-ahead parameter has been set to true the first item will
not be set active per default.