### PR TITLE
Features/activate only set items

### DIFF
--- a/library/ngx-scrollspy/package.json
+++ b/library/ngx-scrollspy/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uniprank/ngx-scrollspy",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "author": {
         "name": "Dennis Fiedler",
         "email": "npm-package@uniprank.com",

--- a/library/ngx-scrollspy/src/lib/scroll-spy.service.spec.ts
+++ b/library/ngx-scrollspy/src/lib/scroll-spy.service.spec.ts
@@ -1,10 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 
 import { ScrollSpyService } from './scroll-spy.service';
+import { NgxScrollspyModule } from './ngx-scrollspy.module';
 
 describe('ScrollSpyService', () => {
     beforeEach(() => {
-        TestBed.configureTestingModule({ providers: [ScrollSpyService] });
+        TestBed.configureTestingModule({
+            imports: [NgxScrollspyModule.forRoot()],
+            providers: [ScrollSpyService]
+        });
     });
 
     it('should be created', () => {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "start": "ng serve --project=TestCases --host=0.0.0.0",
         "build": "ng build",
         "build:testcases": "ng build --project=TestCases --prod",
+        "build:development": "ng build --watch",
         "test": "ng test",
         "lint": "ng lint",
         "publish": "cd dist/ngx-scrollspy && npm publish --access public",


### PR DESCRIPTION
Now its possible to activate the scroll items **only** when the
scroll element has reached the set offset and it is still in the
viewport. This can be set on the config.